### PR TITLE
Update README with reference to dgraph-js-http.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 # dgraph-js [![npm version](https://img.shields.io/npm/v/dgraph-js.svg?style=flat)](https://www.npmjs.com/package/dgraph-js) [![Build Status](https://img.shields.io/travis/dgraph-io/dgraph-js/master.svg?style=flat)](https://travis-ci.org/dgraph-io/dgraph-js) [![Coverage Status](https://img.shields.io/coveralls/github/dgraph-io/dgraph-js/master.svg?style=flat)](https://coveralls.io/github/dgraph-io/dgraph-js?branch=master)
 
-Official Dgraph client implementation for javascript (Node.js v6 and above),
-using [grpc].
+Official Dgraph client implementation for JavaScript (Node.js v6 and above),
+using [gRPC].
+
+**Looking for browser support? Check out [dgraph-js-http].**
 
 [grpc]: https://grpc.io/
+[dgraph-js-http]: https://github.com/dgraph-io/dgraph-js-http
 
 This client follows the [Dgraph Go client][goclient] closely.
 


### PR DESCRIPTION
For folks who need to connect to Dgraph from the browser, they can use Dgraph's HTTP API with [dgraph-js-http][1] instead of dgraph-js which only uses gRPC.

[1]: https://github.com/dgraph-io/dgraph/dgraph-js-http

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph-js/53)
<!-- Reviewable:end -->
