### PR TITLE
Updating ACL tests to sync up changes with Dgraph v1.2

### DIFF
--- a/tests/integration/delete.spec.ts
+++ b/tests/integration/delete.spec.ts
@@ -147,7 +147,7 @@ describe("delete", () => {
                 schools {
                     name
                 }
-                friends {
+                friends (orderasc: name) {
                     name
                     age
                 }


### PR DESCRIPTION
- Removed try..catch block from tryReading() function
- Added tests for when no ACL permission passed
- minor changes in a query for delete test to sort friends by name in ascending order

Signed-off-by: Prashant Shahi <coolboi567@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph-js/103)
<!-- Reviewable:end -->
