### PR TITLE
make dgraph-js compatible grpc-js

### DIFF
--- a/lib/clientStub.js
+++ b/lib/clientStub.js
@@ -147,7 +147,7 @@ var DgraphClientStub = (function () {
 exports.DgraphClientStub = DgraphClientStub;
 function ensureCallOptions(options) {
     return (options === undefined) ? {
-        propagate_flags: grpc.propagate.DEFAULTS,
+        propagate_flags: grpc.propagate ? grpc.propagate.DEFAULTS : 4,
         credentials: undefined,
     } : options;
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@types/jest": "^24.0.13",
     "@types/node": "^12.0.7",
     "coveralls": "^3.0.0",
+    "grpc": "^1.21.1",
     "grpc-tools": "^1.6.6",
     "grpc_tools_node_protoc_ts": "^2.5.3",
     "install-peers": "^1.0.2",
@@ -49,7 +50,6 @@
   },
   "dependencies": {
     "google-protobuf": "^3.8.0",
-    "grpc": "^1.21.1",
     "is-base64": "^0.1.0"
   },
   "peerDependencies": {

--- a/src/clientStub.ts
+++ b/src/clientStub.ts
@@ -160,7 +160,8 @@ export class DgraphClientStub {
 
 function ensureCallOptions(options?: grpc.CallOptions): grpc.CallOptions {
     return (options === undefined) ? {
-        propagate_flags: grpc.propagate.DEFAULTS,
+        // @ts-ignore
+        propagate_flags: grpc.propagate ? grpc.propagate.DEFAULTS : 4,
         credentials: undefined,
     } : options;
 }


### PR DESCRIPTION
make dgraph-js compatible grpc-js

I have replace `grpc` with @types/grpc-js which don't need compile and that is work without change my project code 

I have published a package `@shynome/dgraph-js` that can replace `grpc` package with `@grpc/grpc-js`, you can use the commad replace current  `dgraph-js` and `grpc` package, and your project will work as expected

the command: `yarn add dgraph-js@npm:@shynome/dgraph-js grpc@npm:@grpc/grpc-js`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph-js/107)
<!-- Reviewable:end -->
