### PR TITLE
Add dropOp mutation to example

### DIFF
--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -73,6 +73,24 @@ Number of people named "Alice": 1
   dob: '1980-02-01T17:30:00Z',
   friend: [ { name: 'Bob', age: 24 }, { name: 'Charlie', age: 29 } ],
   school: [ { name: 'Crown Public School' } ] }
+Number of people named "Alice": 0
+Created person named "Alice" with uid = 0x19
+
+All created nodes (map from blank node names to uids):
+alice => 0x19
+dg.3973478125.10 => 0x16
+dg.3973478125.11 => 0x17
+dg.3973478125.12 => 0x18
+
+Number of people named "Alice": 1
+{ uid: '0x19',
+  name: 'Alice',
+  age: 26,
+  married: true,
+  loc: { type: 'Point', coordinates: [ 1.1, 2 ] },
+  dob: '1980-02-01T17:30:00Z',
+  friend: [ { name: 'Bob', age: 24 }, { name: 'Charlie', age: 29 } ],
+  school: [ { name: 'Crown Public School' } ] }
 
 DONE!
 ```

--- a/examples/simple/index.js
+++ b/examples/simple/index.js
@@ -3,7 +3,7 @@ const grpc = require("grpc");
 
 // Create a client stub.
 function newClientStub() {
-    return new dgraph.DgraphClientStub("localhost:9080", grpc.credentials.createInsecure());
+    return new dgraph.DgraphClientStub("localhost:9080");
 }
 
 // Create a client.
@@ -11,10 +11,17 @@ function newClient(clientStub) {
     return new dgraph.DgraphClient(clientStub);
 }
 
-// Drop All - discard all data and start from a clean slate.
+// Drop All - discard all data, schema and start from a clean slate.
 async function dropAll(dgraphClient) {
     const op = new dgraph.Operation();
     op.setDropAll(true);
+    await dgraphClient.alter(op);
+}
+
+// Drop All Data, but keep the schema.
+async function dropData(dgraphClient) {
+    const op = new dgraph.Operation();
+    op.setDropOp(dgraph.Operation.DropOp.DATA);
     await dgraphClient.alter(op);
 }
 
@@ -123,6 +130,10 @@ async function main() {
     const dgraphClient = newClient(dgraphClientStub);
     await dropAll(dgraphClient);
     await setSchema(dgraphClient);
+    await createData(dgraphClient);
+    await queryData(dgraphClient);
+    await dropData(dgraphClient);
+    await queryData(dgraphClient);
     await createData(dgraphClient);
     await queryData(dgraphClient);
 


### PR DESCRIPTION
Currently in index.js, there is no example of dropping all data, while keeping the schema. 

It was found out that the format of dropOp query is unintuitive. Hence, adding an example to index.js

Related Discuss link: https://discuss.dgraph.io/t/how-do-i-drop-data-using-the-js-library/9744

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph-js/123)
<!-- Reviewable:end -->
