### PR TITLE
Add support for default export

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1,9 +1,10 @@
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
@@ -35,6 +36,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.deleteEdges = exports.isJwtExpired = exports.DgraphClient = void 0;
 var messages = require("../generated/api_pb");
 var errors_1 = require("./errors");
 var txn_1 = require("./txn");

--- a/lib/clientStub.js
+++ b/lib/clientStub.js
@@ -1,9 +1,10 @@
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
@@ -35,6 +36,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.DgraphClientStub = void 0;
 var grpc = require("grpc");
 var services = require("../generated/api_grpc_pb");
 var messages = require("../generated/api_pb");

--- a/lib/dgraph.d.ts
+++ b/lib/dgraph.d.ts
@@ -1,0 +1,6 @@
+export * from "./types";
+export { Operation, Request, TxnContext, Check, Version, NQuad, Value, Facet, Latency, } from "../generated/api_pb";
+export * from "./clientStub";
+export * from "./client";
+export * from "./txn";
+export * from "./errors";

--- a/lib/dgraph.js
+++ b/lib/dgraph.js
@@ -1,0 +1,27 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __exportStar = (this && this.__exportStar) || function(m, exports) {
+    for (var p in m) if (p !== "default" && !exports.hasOwnProperty(p)) __createBinding(exports, m, p);
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+__exportStar(require("./types"), exports);
+var api_pb_1 = require("../generated/api_pb");
+Object.defineProperty(exports, "Operation", { enumerable: true, get: function () { return api_pb_1.Operation; } });
+Object.defineProperty(exports, "Request", { enumerable: true, get: function () { return api_pb_1.Request; } });
+Object.defineProperty(exports, "TxnContext", { enumerable: true, get: function () { return api_pb_1.TxnContext; } });
+Object.defineProperty(exports, "Check", { enumerable: true, get: function () { return api_pb_1.Check; } });
+Object.defineProperty(exports, "Version", { enumerable: true, get: function () { return api_pb_1.Version; } });
+Object.defineProperty(exports, "NQuad", { enumerable: true, get: function () { return api_pb_1.NQuad; } });
+Object.defineProperty(exports, "Value", { enumerable: true, get: function () { return api_pb_1.Value; } });
+Object.defineProperty(exports, "Facet", { enumerable: true, get: function () { return api_pb_1.Facet; } });
+Object.defineProperty(exports, "Latency", { enumerable: true, get: function () { return api_pb_1.Latency; } });
+__exportStar(require("./clientStub"), exports);
+__exportStar(require("./client"), exports);
+__exportStar(require("./txn"), exports);
+__exportStar(require("./errors"), exports);

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.ERR_REFRESH_JWT_EMPTY = exports.ERR_READ_ONLY = exports.ERR_BEST_EFFORT_REQUIRED_READ_ONLY = exports.ERR_ABORTED = exports.ERR_FINISHED = exports.ERR_NO_CLIENTS = void 0;
 exports.ERR_NO_CLIENTS = new Error("No clients provided in DgraphClient constructor");
 exports.ERR_FINISHED = new Error("Transaction has already been committed or discarded");
 exports.ERR_ABORTED = new Error("Transaction has been aborted. Please retry");

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,6 +1,3 @@
-export * from "./types";
-export { Operation, Request, TxnContext, Check, Version, NQuad, Value, Facet, Latency, } from "../generated/api_pb";
-export * from "./clientStub";
-export * from "./client";
-export * from "./txn";
-export * from "./errors";
+import * as dgraph from './dgraph';
+export * from "./dgraph";
+export default dgraph;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,20 +1,15 @@
 "use strict";
-function __export(m) {
-    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
-}
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __exportStar = (this && this.__exportStar) || function(m, exports) {
+    for (var p in m) if (p !== "default" && !exports.hasOwnProperty(p)) __createBinding(exports, m, p);
+};
 Object.defineProperty(exports, "__esModule", { value: true });
-__export(require("./types"));
-var api_pb_1 = require("../generated/api_pb");
-exports.Operation = api_pb_1.Operation;
-exports.Request = api_pb_1.Request;
-exports.TxnContext = api_pb_1.TxnContext;
-exports.Check = api_pb_1.Check;
-exports.Version = api_pb_1.Version;
-exports.NQuad = api_pb_1.NQuad;
-exports.Value = api_pb_1.Value;
-exports.Facet = api_pb_1.Facet;
-exports.Latency = api_pb_1.Latency;
-__export(require("./clientStub"));
-__export(require("./client"));
-__export(require("./txn"));
-__export(require("./errors"));
+var dgraph = require("./dgraph");
+__exportStar(require("./dgraph"), exports);
+exports.default = dgraph;

--- a/lib/txn.js
+++ b/lib/txn.js
@@ -11,10 +11,11 @@ var __assign = (this && this.__assign) || function () {
     return __assign.apply(this, arguments);
 };
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
@@ -46,6 +47,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.Txn = void 0;
 var messages = require("../generated/api_pb");
 var client_1 = require("./client");
 var errors_1 = require("./errors");

--- a/lib/types.js
+++ b/lib/types.js
@@ -13,6 +13,7 @@ var __extends = (this && this.__extends) || (function () {
     };
 })();
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.Mutation = exports.createResponse = exports.Response = exports.createPayload = exports.Payload = void 0;
 var jspb = require("google-protobuf");
 var messages = require("../generated/api_pb");
 var util_1 = require("./util");

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.strToJson = exports.u8ToStr = exports.b64ToStr = exports.strToU8 = exports.strToB64 = exports.stringifyMessage = exports.promisify3 = exports.promisify1 = exports.isUnauthenticatedError = exports.isConflictError = exports.isAbortedError = exports.errorCode = void 0;
 var grpc = require("grpc");
 function errorCode(err) {
     if (err === undefined ||
@@ -53,7 +54,7 @@ function stringifyMessage(msg) {
 }
 exports.stringifyMessage = stringifyMessage;
 var is_base64_1 = require("is-base64");
-exports.isBase64 = is_base64_1.isBase64;
+Object.defineProperty(exports, "isBase64", { enumerable: true, get: function () { return is_base64_1.isBase64; } });
 function strToB64(str) {
     return Buffer.from(str, "utf8").toString("base64");
 }

--- a/src/dgraph.ts
+++ b/src/dgraph.ts
@@ -1,0 +1,25 @@
+// Export all the required message types.
+export * from "./types";
+export {
+    Operation,
+    Request,
+    TxnContext,
+    Check,
+    Version,
+    NQuad,
+    Value,
+    Facet,
+    Latency,
+} from "../generated/api_pb";
+
+// Export DgraphClientStub class.
+export * from "./clientStub";
+
+// Export DgraphClient class and deleteEdges function.
+export * from "./client";
+
+// Export Txn class.
+export * from "./txn";
+
+// Export error constants.
+export * from "./errors";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,25 +1,4 @@
-// Export all the required message types.
-export * from "./types";
-export {
-    Operation,
-    Request,
-    TxnContext,
-    Check,
-    Version,
-    NQuad,
-    Value,
-    Facet,
-    Latency,
-} from "../generated/api_pb";
+import * as dgraph from './dgraph';
 
-// Export DgraphClientStub class.
-export * from "./clientStub";
-
-// Export DgraphClient class and deleteEdges function.
-export * from "./client";
-
-// Export Txn class.
-export * from "./txn";
-
-// Export error constants.
-export * from "./errors";
+export * from "./dgraph";
+export default dgraph;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import * as dgraph from './dgraph';
+import * as dgraph from "./dgraph";
 
 export * from "./dgraph";
 export default dgraph;

--- a/tslint.json
+++ b/tslint.json
@@ -15,6 +15,7 @@
     "insecure-random": false,
     "no-multiline-string": false,
     "newline-per-chained-call": false,
+    "no-default-export": false,
     "trailing-comma": [
       true,
       {


### PR DESCRIPTION
This PR adds support for default export. Now this is possible - 
```js
import dgraph from 'dgraph-js';
```
Also continue to support -
```js
import * as dgraph from 'dgraph-js';
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph-js/124)
<!-- Reviewable:end -->
