### PR TITLE
chore: Sync api.proto & deprecate Slash endpoint method 

### DIFF
--- a/generated/api_pb.d.ts
+++ b/generated/api_pb.d.ts
@@ -441,9 +441,6 @@ export class NQuad extends jspb.Message {
   getObjectValue(): Value | undefined;
   setObjectValue(value?: Value): void;
 
-  getLabel(): string;
-  setLabel(value: string): void;
-
   getLang(): string;
   setLang(value: string): void;
 
@@ -471,7 +468,6 @@ export namespace NQuad {
     predicate: string,
     objectId: string,
     objectValue?: Value.AsObject,
-    label: string,
     lang: string,
     facetsList: Array<Facet.AsObject>,
     namespace: number,

--- a/generated/api_pb.d.ts
+++ b/generated/api_pb.d.ts
@@ -29,6 +29,9 @@ export class Request extends jspb.Message {
   getRespFormat(): Request.RespFormatMap[keyof Request.RespFormatMap];
   setRespFormat(value: Request.RespFormatMap[keyof Request.RespFormatMap]): void;
 
+  getHash(): string;
+  setHash(value: string): void;
+
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): Request.AsObject;
   static toObject(includeInstance: boolean, msg: Request): Request.AsObject;
@@ -49,6 +52,7 @@ export namespace Request {
     mutationsList: Array<Mutation.AsObject>,
     commitNow: boolean,
     respFormat: Request.RespFormatMap[keyof Request.RespFormatMap],
+    hash: string,
   }
 
   export interface RespFormatMap {
@@ -307,6 +311,9 @@ export class TxnContext extends jspb.Message {
   setPredsList(value: Array<string>): void;
   addPreds(value: string, index?: number): string;
 
+  getHash(): string;
+  setHash(value: string): void;
+
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): TxnContext.AsObject;
   static toObject(includeInstance: boolean, msg: TxnContext): TxnContext.AsObject;
@@ -324,6 +331,7 @@ export namespace TxnContext {
     aborted: boolean,
     keysList: Array<string>,
     predsList: Array<string>,
+    hash: string,
   }
 }
 

--- a/generated/api_pb.js
+++ b/generated/api_pb.js
@@ -3458,7 +3458,6 @@ proto.api.NQuad.toObject = function(includeInstance, msg) {
     predicate: jspb.Message.getFieldWithDefault(msg, 2, ""),
     objectId: jspb.Message.getFieldWithDefault(msg, 3, ""),
     objectValue: (f = msg.getObjectValue()) && proto.api.Value.toObject(includeInstance, f),
-    label: jspb.Message.getFieldWithDefault(msg, 5, ""),
     lang: jspb.Message.getFieldWithDefault(msg, 6, ""),
     facetsList: jspb.Message.toObjectList(msg.getFacetsList(),
     proto.api.Facet.toObject, includeInstance),
@@ -3515,10 +3514,6 @@ proto.api.NQuad.deserializeBinaryFromReader = function(msg, reader) {
       var value = new proto.api.Value;
       reader.readMessage(value,proto.api.Value.deserializeBinaryFromReader);
       msg.setObjectValue(value);
-      break;
-    case 5:
-      var value = /** @type {string} */ (reader.readString());
-      msg.setLabel(value);
       break;
     case 6:
       var value = /** @type {string} */ (reader.readString());
@@ -3589,13 +3584,6 @@ proto.api.NQuad.serializeBinaryToWriter = function(message, writer) {
       4,
       f,
       proto.api.Value.serializeBinaryToWriter
-    );
-  }
-  f = message.getLabel();
-  if (f.length > 0) {
-    writer.writeString(
-      5,
-      f
     );
   }
   f = message.getLang();
@@ -3711,24 +3699,6 @@ proto.api.NQuad.prototype.clearObjectValue = function() {
  */
 proto.api.NQuad.prototype.hasObjectValue = function() {
   return jspb.Message.getField(this, 4) != null;
-};
-
-
-/**
- * optional string label = 5;
- * @return {string}
- */
-proto.api.NQuad.prototype.getLabel = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 5, ""));
-};
-
-
-/**
- * @param {string} value
- * @return {!proto.api.NQuad} returns this
- */
-proto.api.NQuad.prototype.setLabel = function(value) {
-  return jspb.Message.setProto3StringField(this, 5, value);
 };
 
 

--- a/generated/api_pb.js
+++ b/generated/api_pb.js
@@ -439,7 +439,8 @@ proto.api.Request.toObject = function(includeInstance, msg) {
     mutationsList: jspb.Message.toObjectList(msg.getMutationsList(),
     proto.api.Mutation.toObject, includeInstance),
     commitNow: jspb.Message.getBooleanFieldWithDefault(msg, 13, false),
-    respFormat: jspb.Message.getFieldWithDefault(msg, 14, 0)
+    respFormat: jspb.Message.getFieldWithDefault(msg, 14, 0),
+    hash: jspb.Message.getFieldWithDefault(msg, 15, "")
   };
 
   if (includeInstance) {
@@ -510,6 +511,10 @@ proto.api.Request.deserializeBinaryFromReader = function(msg, reader) {
     case 14:
       var value = /** @type {!proto.api.Request.RespFormat} */ (reader.readEnum());
       msg.setRespFormat(value);
+      break;
+    case 15:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setHash(value);
       break;
     default:
       reader.skipField();
@@ -591,6 +596,13 @@ proto.api.Request.serializeBinaryToWriter = function(message, writer) {
   if (f !== 0.0) {
     writer.writeEnum(
       14,
+      f
+    );
+  }
+  f = message.getHash();
+  if (f.length > 0) {
+    writer.writeString(
+      15,
       f
     );
   }
@@ -770,6 +782,24 @@ proto.api.Request.prototype.getRespFormat = function() {
  */
 proto.api.Request.prototype.setRespFormat = function(value) {
   return jspb.Message.setProto3EnumField(this, 14, value);
+};
+
+
+/**
+ * optional string hash = 15;
+ * @return {string}
+ */
+proto.api.Request.prototype.getHash = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 15, ""));
+};
+
+
+/**
+ * @param {string} value
+ * @return {!proto.api.Request} returns this
+ */
+proto.api.Request.prototype.setHash = function(value) {
+  return jspb.Message.setProto3StringField(this, 15, value);
 };
 
 
@@ -2489,7 +2519,8 @@ proto.api.TxnContext.toObject = function(includeInstance, msg) {
     commitTs: jspb.Message.getFieldWithDefault(msg, 2, 0),
     aborted: jspb.Message.getBooleanFieldWithDefault(msg, 3, false),
     keysList: (f = jspb.Message.getRepeatedField(msg, 4)) == null ? undefined : f,
-    predsList: (f = jspb.Message.getRepeatedField(msg, 5)) == null ? undefined : f
+    predsList: (f = jspb.Message.getRepeatedField(msg, 5)) == null ? undefined : f,
+    hash: jspb.Message.getFieldWithDefault(msg, 6, "")
   };
 
   if (includeInstance) {
@@ -2545,6 +2576,10 @@ proto.api.TxnContext.deserializeBinaryFromReader = function(msg, reader) {
     case 5:
       var value = /** @type {string} */ (reader.readString());
       msg.addPreds(value);
+      break;
+    case 6:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setHash(value);
       break;
     default:
       reader.skipField();
@@ -2607,6 +2642,13 @@ proto.api.TxnContext.serializeBinaryToWriter = function(message, writer) {
   if (f.length > 0) {
     writer.writeRepeatedString(
       5,
+      f
+    );
+  }
+  f = message.getHash();
+  if (f.length > 0) {
+    writer.writeString(
+      6,
       f
     );
   }
@@ -2738,6 +2780,24 @@ proto.api.TxnContext.prototype.addPreds = function(value, opt_index) {
  */
 proto.api.TxnContext.prototype.clearPredsList = function() {
   return this.setPredsList([]);
+};
+
+
+/**
+ * optional string hash = 6;
+ * @return {string}
+ */
+proto.api.TxnContext.prototype.getHash = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 6, ""));
+};
+
+
+/**
+ * @param {string} value
+ * @return {!proto.api.TxnContext} returns this
+ */
+proto.api.TxnContext.prototype.setHash = function(value) {
+  return jspb.Message.setProto3StringField(this, 6, value);
 };
 
 

--- a/lib/clientStubFromSlash.js
+++ b/lib/clientStubFromSlash.js
@@ -6,6 +6,7 @@ var Url = require("url-parse");
 var clientStub_1 = require("./clientStub");
 var PORT = "443";
 function clientStubFromSlashGraphQLEndpoint(graphqlEndpoint, apiKey) {
+    console.warn("This method is deprecated and will be removed in v21.07 release.");
     var url = new Url(graphqlEndpoint);
     var urlParts = url.host.split(".");
     var firstHalf = urlParts[0];

--- a/lib/clientStubFromSlash.js
+++ b/lib/clientStubFromSlash.js
@@ -6,7 +6,6 @@ var Url = require("url-parse");
 var clientStub_1 = require("./clientStub");
 var PORT = "443";
 function clientStubFromSlashGraphQLEndpoint(graphqlEndpoint, apiKey) {
-    console.warn("This method is deprecated and will be removed in v21.07 release.");
     var url = new Url(graphqlEndpoint);
     var urlParts = url.host.split(".");
     var firstHalf = urlParts[0];

--- a/lib/txn.js
+++ b/lib/txn.js
@@ -161,6 +161,7 @@ var Txn = (function () {
                             this.mutated = true;
                         }
                         req.setStartTs(this.ctx.getStartTs());
+                        req.setHash(this.ctx.getHash());
                         this.dc.debug("Do request:\n" + util_1.stringifyMessage(req));
                         c = this.dc.anyClient();
                         operation = function () { return __awaiter(_this, void 0, void 0, function () { return __generator(this, function (_a) {
@@ -296,6 +297,7 @@ var Txn = (function () {
         if (src === undefined) {
             return;
         }
+        this.ctx.setHash(src.getHash());
         if (this.ctx.getStartTs() === 0) {
             this.ctx.setStartTs(src.getStartTs());
         }

--- a/protos/api.proto
+++ b/protos/api.proto
@@ -57,6 +57,7 @@ message Request {
 		RDF = 1;
 	}
 	RespFormat resp_format = 14;
+	string hash = 15;
 }
 
 message Uids {
@@ -128,6 +129,7 @@ message TxnContext {
 	bool aborted = 3;
 	repeated string keys = 4;  // List of keys to be used for conflict detection.
 	repeated string preds = 5; // List of predicates involved in this transaction.
+	string hash = 6;
 }
 
 message Check {}

--- a/protos/api.proto
+++ b/protos/api.proto
@@ -152,11 +152,11 @@ message Metrics {
 }
 
 message NQuad {
+	reserved 5; // This was used for label.
 	string subject = 1;
 	string predicate = 2;
 	string object_id = 3;
 	Value object_value = 4;
-	string label = 5;
 	string lang = 6;
 	repeated Facet facets = 7;
 	uint64 namespace = 8;

--- a/src/clientStubFromSlash.ts
+++ b/src/clientStubFromSlash.ts
@@ -3,10 +3,15 @@ import * as Url from "url-parse";
 import { DgraphClientStub } from "./clientStub";
 
 const PORT = "443";
+/** 
+* @deprecated since v21.3 and will be removed in v21.07 release.
+*/
+
 export function clientStubFromSlashGraphQLEndpoint(
     graphqlEndpoint: string,
     apiKey: string,
 ) {
+    console.warn("This method is deprecated and will be removed in v21.07 release.");
     const url = new Url(graphqlEndpoint);
     const urlParts = url.host.split(".");
     const firstHalf = urlParts[0];

--- a/src/clientStubFromSlash.ts
+++ b/src/clientStubFromSlash.ts
@@ -3,9 +3,9 @@ import * as Url from "url-parse";
 import { DgraphClientStub } from "./clientStub";
 
 const PORT = "443";
-/** 
-* @deprecated since v21.3 and will be removed in v21.07 release.
-*/
+/**
+ * @deprecated since v21.3 and will be removed in v21.07 release.
+ */
 
 export function clientStubFromSlashGraphQLEndpoint(
     graphqlEndpoint: string,

--- a/src/clientStubFromSlash.ts
+++ b/src/clientStubFromSlash.ts
@@ -4,14 +4,14 @@ import { DgraphClientStub } from "./clientStub";
 
 const PORT = "443";
 /**
- * @deprecated since v21.3 and will be removed in v21.07 release.
+ * @deprecated since v21.3 and will be removed in v21.07 release. For more details, see:
+ *     https://discuss.dgraph.io/t/regarding-slash-cloud-dgraph-endpoints-in-the-clients/13492
  */
 
 export function clientStubFromSlashGraphQLEndpoint(
     graphqlEndpoint: string,
     apiKey: string,
 ) {
-    console.warn("This method is deprecated and will be removed in v21.07 release.");
     const url = new Url(graphqlEndpoint);
     const urlParts = url.host.split(".");
     const firstHalf = urlParts[0];

--- a/src/txn.ts
+++ b/src/txn.ts
@@ -212,6 +212,7 @@ export class Txn {
         }
 
         req.setStartTs(this.ctx.getStartTs());
+        req.setHash(this.ctx.getHash());
         this.dc.debug(`Do request:\n${stringifyMessage(req)}`);
 
         let resp: types.Response;
@@ -331,6 +332,8 @@ export class Txn {
             // This condition will be true only if the server doesn't return a txn context after a query or mutation.
             return;
         }
+
+        this.ctx.setHash(src.getHash());
 
         if (this.ctx.getStartTs() === 0) {
             this.ctx.setStartTs(src.getStartTs());

--- a/tests/integration/acl.spec.ts
+++ b/tests/integration/acl.spec.ts
@@ -12,7 +12,7 @@ jest.setTimeout(JEST_TIMEOUT);
 
 let client: dgraph.DgraphClient;
 
-const GROOT_PWD = "password";
+const GUARDIAN_CREDS = "user=groot;password=password;namespace=0";
 const USERID = "alice";
 const USERPWD = "alicepassword";
 const PRED = "name";
@@ -71,22 +71,22 @@ async function aclSetup() {
 }
 
 async function addUser() {
-    const command = `dgraph acl -a ${SERVER_ADDR} add -u ${USERID} -p ${USERPWD} -x ${GROOT_PWD}`;
+    const command = `dgraph acl -a ${SERVER_ADDR} add -u ${USERID} -p ${USERPWD} --guardian-creds ${GUARDIAN_CREDS}`;
     await cmd(command);
 }
 
 async function addGroup() {
-    const command = `dgraph acl -a ${SERVER_ADDR} add -g ${DEV_GROUP} -x ${GROOT_PWD}`;
+    const command = `dgraph acl -a ${SERVER_ADDR} add -g ${DEV_GROUP} --guardian-creds ${GUARDIAN_CREDS}`;
     await cmd(command);
 }
 
 async function addUserToGroup() {
-    const command = `dgraph acl -a ${SERVER_ADDR} mod -u ${USERID} -l ${DEV_GROUP} -x ${GROOT_PWD}`;
+    const command = `dgraph acl -a ${SERVER_ADDR} mod -u ${USERID} -l ${DEV_GROUP} --guardian-creds ${GUARDIAN_CREDS}`;
     await cmd(command);
 }
 
 async function changePermission(permission: number) {
-    const command = `dgraph acl -a ${SERVER_ADDR} mod -g ${DEV_GROUP} -p ${PRED} -m ${permission} -x ${GROOT_PWD}`;
+    const command = `dgraph acl -a ${SERVER_ADDR} mod -g ${DEV_GROUP} -p ${PRED} -m ${permission} ---guardian-creds ${GUARDIAN_CREDS}`;
     await cmd(command);
     await wait(WAIT_FOR_SIX_SECONDS);
 }

--- a/tests/integration/acl.spec.ts
+++ b/tests/integration/acl.spec.ts
@@ -71,22 +71,22 @@ async function aclSetup() {
 }
 
 async function addUser() {
-    const command = `dgraph acl -a ${SERVER_ADDR} add -u ${USERID} -p ${USERPWD} --guardian-creds ${GUARDIAN_CREDS}`;
+    const command = `dgraph acl -a \'${SERVER_ADDR}\' add -u \'${USERID}\' -p \'${USERPWD}\' --guardian-creds \'${GUARDIAN_CREDS}\'`;
     await cmd(command);
 }
 
 async function addGroup() {
-    const command = `dgraph acl -a ${SERVER_ADDR} add -g ${DEV_GROUP} --guardian-creds ${GUARDIAN_CREDS}`;
+    const command = `dgraph acl -a \'${SERVER_ADDR}\' add -g \'${DEV_GROUP}\' --guardian-creds \'${GUARDIAN_CREDS}\'`;
     await cmd(command);
 }
 
 async function addUserToGroup() {
-    const command = `dgraph acl -a ${SERVER_ADDR} mod -u ${USERID} -l ${DEV_GROUP} --guardian-creds ${GUARDIAN_CREDS}`;
+    const command = `dgraph acl -a \'${SERVER_ADDR}\' mod -u \'${USERID}\' -l \'${DEV_GROUP}\' --guardian-creds \'${GUARDIAN_CREDS}\'`;
     await cmd(command);
 }
 
 async function changePermission(permission: number) {
-    const command = `dgraph acl -a ${SERVER_ADDR} mod -g ${DEV_GROUP} -p ${PRED} -m ${permission} --guardian-creds ${GUARDIAN_CREDS}`;
+    const command = `dgraph acl -a \'${SERVER_ADDR}\' mod -g \'${DEV_GROUP}\' -p \'${PRED}\' -m \'${permission}\' --guardian-creds \'${GUARDIAN_CREDS}\'`;
     await cmd(command);
     await wait(WAIT_FOR_SIX_SECONDS);
 }

--- a/tests/integration/acl.spec.ts
+++ b/tests/integration/acl.spec.ts
@@ -86,7 +86,7 @@ async function addUserToGroup() {
 }
 
 async function changePermission(permission: number) {
-    const command = `dgraph acl -a ${SERVER_ADDR} mod -g ${DEV_GROUP} -p ${PRED} -m ${permission} ---guardian-creds ${GUARDIAN_CREDS}`;
+    const command = `dgraph acl -a ${SERVER_ADDR} mod -g ${DEV_GROUP} -p ${PRED} -m ${permission} --guardian-creds ${GUARDIAN_CREDS}`;
     await cmd(command);
     await wait(WAIT_FOR_SIX_SECONDS);
 }


### PR DESCRIPTION
* Make transaction context more robust.
* Deprecate `clientStubFromSlashGraphQLEndpoint` method.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph-js/135)
<!-- Reviewable:end -->
