### PR TITLE
fix(deprecation): add clientStubFromCloudEndpoint method

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,14 +128,14 @@ If you want to connect to Dgraph running on your [Dgraph Cloud](https://cloud.dg
 ```js
 const dgraph = require("dgraph-js");
 
-const clientStub = dgraph.clientStubFromSlashGraphQLEndpoint(
+const clientStub = dgraph.clientStubFromCloudEndpoint(
   "https://frozen-mango.eu-central-1.aws.cloud.dgraph.io/graphql",
   "<api-key>"
 );
 const dgraphClient = new dgraph.DgraphClient(clientStub);
 ```
 
-**Note:** the `clientStubFromSlashGraphQLEndpoint` method is deprecated and will be removed in the next release.
+**Note:** the `clientStubFromSlashGraphQLEndpoint` method is deprecated and will be removed in the next release. Instead use `clientStubFromCloudEndpoint` method.
 
 ### Altering the Database
 
@@ -499,4 +499,3 @@ Make sure you have a Dgraph server running on localhost before you run this task
 ```sh
 npm test
 ```
-

--- a/lib/client.js
+++ b/lib/client.js
@@ -36,7 +36,6 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.deleteEdges = exports.isJwtExpired = exports.DgraphClient = void 0;
 var messages = require("../generated/api_pb");
 var errors_1 = require("./errors");
 var txn_1 = require("./txn");

--- a/lib/clientStub.js
+++ b/lib/clientStub.js
@@ -36,7 +36,6 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.DgraphClientStub = void 0;
 var grpc = require("@grpc/grpc-js");
 var services = require("../generated/api_grpc_pb");
 var messages = require("../generated/api_pb");

--- a/lib/clientStubFromSlash.d.ts
+++ b/lib/clientStubFromSlash.d.ts
@@ -1,2 +1,3 @@
 import { DgraphClientStub } from "./clientStub";
 export declare function clientStubFromSlashGraphQLEndpoint(graphqlEndpoint: string, apiKey: string): DgraphClientStub;
+export declare function clientStubFromCloudEndpoint(graphqlEndpoint: string, apiKey: string): DgraphClientStub;

--- a/lib/clientStubFromSlash.js
+++ b/lib/clientStubFromSlash.js
@@ -1,11 +1,14 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.clientStubFromSlashGraphQLEndpoint = void 0;
 var grpc = require("@grpc/grpc-js");
 var Url = require("url-parse");
 var clientStub_1 = require("./clientStub");
 var PORT = "443";
 function clientStubFromSlashGraphQLEndpoint(graphqlEndpoint, apiKey) {
+    return clientStubFromCloudEndpoint(graphqlEndpoint, apiKey);
+}
+exports.clientStubFromSlashGraphQLEndpoint = clientStubFromSlashGraphQLEndpoint;
+function clientStubFromCloudEndpoint(graphqlEndpoint, apiKey) {
     var url = new Url(graphqlEndpoint);
     var urlParts = url.host.split(".");
     var firstHalf = urlParts[0];
@@ -19,4 +22,4 @@ function clientStubFromSlashGraphQLEndpoint(graphqlEndpoint, apiKey) {
     var credentials = grpc.credentials.combineChannelCredentials(grpc.credentials.createSsl(), metaCreds);
     return new clientStub_1.DgraphClientStub(backenedURL, credentials);
 }
-exports.clientStubFromSlashGraphQLEndpoint = clientStubFromSlashGraphQLEndpoint;
+exports.clientStubFromCloudEndpoint = clientStubFromCloudEndpoint;

--- a/lib/dgraph.js
+++ b/lib/dgraph.js
@@ -1,29 +1,22 @@
 "use strict";
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __exportStar = (this && this.__exportStar) || function(m, exports) {
-    for (var p in m) if (p !== "default" && !exports.hasOwnProperty(p)) __createBinding(exports, m, p);
-};
+function __export(m) {
+    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+}
 Object.defineProperty(exports, "__esModule", { value: true });
-__exportStar(require("./types"), exports);
+__export(require("./types"));
 var api_pb_1 = require("../generated/api_pb");
-Object.defineProperty(exports, "Operation", { enumerable: true, get: function () { return api_pb_1.Operation; } });
-Object.defineProperty(exports, "Request", { enumerable: true, get: function () { return api_pb_1.Request; } });
-Object.defineProperty(exports, "TxnContext", { enumerable: true, get: function () { return api_pb_1.TxnContext; } });
-Object.defineProperty(exports, "Check", { enumerable: true, get: function () { return api_pb_1.Check; } });
-Object.defineProperty(exports, "Version", { enumerable: true, get: function () { return api_pb_1.Version; } });
-Object.defineProperty(exports, "NQuad", { enumerable: true, get: function () { return api_pb_1.NQuad; } });
-Object.defineProperty(exports, "Value", { enumerable: true, get: function () { return api_pb_1.Value; } });
-Object.defineProperty(exports, "Facet", { enumerable: true, get: function () { return api_pb_1.Facet; } });
-Object.defineProperty(exports, "Latency", { enumerable: true, get: function () { return api_pb_1.Latency; } });
-__exportStar(require("./clientStub"), exports);
-__exportStar(require("./client"), exports);
-__exportStar(require("./clientStubFromSlash"), exports);
-__exportStar(require("./txn"), exports);
-__exportStar(require("./errors"), exports);
+exports.Operation = api_pb_1.Operation;
+exports.Request = api_pb_1.Request;
+exports.TxnContext = api_pb_1.TxnContext;
+exports.Check = api_pb_1.Check;
+exports.Version = api_pb_1.Version;
+exports.NQuad = api_pb_1.NQuad;
+exports.Value = api_pb_1.Value;
+exports.Facet = api_pb_1.Facet;
+exports.Latency = api_pb_1.Latency;
+__export(require("./clientStub"));
+__export(require("./client"));
+__export(require("./clientStubFromSlash"));
+__export(require("./txn"));
+__export(require("./errors"));
 exports.grpc = require("@grpc/grpc-js");

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,6 +1,5 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.ERR_REFRESH_JWT_EMPTY = exports.ERR_READ_ONLY = exports.ERR_BEST_EFFORT_REQUIRED_READ_ONLY = exports.ERR_ABORTED = exports.ERR_FINISHED = exports.ERR_NO_CLIENTS = void 0;
 exports.ERR_NO_CLIENTS = new Error("No clients provided in DgraphClient constructor");
 exports.ERR_FINISHED = new Error("Transaction has already been committed or discarded");
 exports.ERR_ABORTED = new Error("Transaction has been aborted. Please retry");

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,15 +1,8 @@
 "use strict";
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __exportStar = (this && this.__exportStar) || function(m, exports) {
-    for (var p in m) if (p !== "default" && !exports.hasOwnProperty(p)) __createBinding(exports, m, p);
-};
+function __export(m) {
+    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+}
 Object.defineProperty(exports, "__esModule", { value: true });
 var dgraph = require("./dgraph");
-__exportStar(require("./dgraph"), exports);
+__export(require("./dgraph"));
 exports.default = dgraph;

--- a/lib/txn.js
+++ b/lib/txn.js
@@ -47,7 +47,6 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.Txn = void 0;
 var messages = require("../generated/api_pb");
 var client_1 = require("./client");
 var errors_1 = require("./errors");

--- a/lib/types.js
+++ b/lib/types.js
@@ -13,7 +13,6 @@ var __extends = (this && this.__extends) || (function () {
     };
 })();
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.Mutation = exports.createResponse = exports.Response = exports.createPayload = exports.Payload = void 0;
 var jspb = require("google-protobuf");
 var messages = require("../generated/api_pb");
 var util_1 = require("./util");

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,6 +1,5 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.strToJson = exports.u8ToStr = exports.b64ToStr = exports.strToU8 = exports.strToB64 = exports.stringifyMessage = exports.promisify3 = exports.promisify1 = exports.isUnauthenticatedError = exports.isConflictError = exports.isAbortedError = exports.errorCode = void 0;
 var grpc = require("@grpc/grpc-js");
 function errorCode(err) {
     if (err === undefined ||
@@ -64,7 +63,7 @@ function stringifyMessage(msg) {
 }
 exports.stringifyMessage = stringifyMessage;
 var is_base64_1 = require("is-base64");
-Object.defineProperty(exports, "isBase64", { enumerable: true, get: function () { return is_base64_1.isBase64; } });
+exports.isBase64 = is_base64_1.isBase64;
 function strToB64(str) {
     return Buffer.from(str, "utf8").toString("base64");
 }

--- a/src/clientStubFromSlash.ts
+++ b/src/clientStubFromSlash.ts
@@ -4,11 +4,18 @@ import { DgraphClientStub } from "./clientStub";
 
 const PORT = "443";
 /**
- * @deprecated since v21.3 and will be removed in v21.07 release. For more details, see:
- *     https://discuss.dgraph.io/t/regarding-slash-cloud-dgraph-endpoints-in-the-clients/13492
+ * @deprecated since v21.3 and will be removed in v21.07 release.
+ *     Please use {@link clientStubFromCloudEndpoint} instead.
  */
 
 export function clientStubFromSlashGraphQLEndpoint(
+    graphqlEndpoint: string,
+    apiKey: string,
+) {
+    return clientStubFromCloudEndpoint(graphqlEndpoint, apiKey);
+}
+
+export function clientStubFromCloudEndpoint(
     graphqlEndpoint: string,
     apiKey: string,
 ) {


### PR DESCRIPTION
This PR adds `clientStubFromCloudEndpoint` and makes `clientStubFromSlashGraphQLEndpoint` deprecated method to use it instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph-js/138)
<!-- Reviewable:end -->
