### PR TITLE
bump @grpc/grpc-js to a static version

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "typescript": "^3.5.1"
   },
   "dependencies": {
-    "@grpc/grpc-js": "^1.2.5",
+    "@grpc/grpc-js": "1.8.0",
     "@types/url-parse": "^1.4.3",
     "google-protobuf": "^3.14.0",
     "is-base64": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "typescript": "^3.5.1"
   },
   "dependencies": {
-    "@grpc/grpc-js": "1.8.0",
+    "@grpc/grpc-js": "1.8.1",
     "@types/url-parse": "^1.4.3",
     "google-protobuf": "^3.14.0",
     "is-base64": "^1.1.0",


### PR DESCRIPTION
Due to [a bug](https://github.com/grpc/grpc-node/issues/2318) with `@grpc/grpc-js` [v1.8.2](https://github.com/grpc/grpc-node/releases/tag/%40grpc%2Fgrpc-js%401.8.2), the `dgraph-js` library fails to properly close GRPC calls causing mass failures across any applications utilizing this library to perform queries against DGraph.

Since `dgraph-js` opts into patch version updates via the caret symbol `^` for this specific dependency, this caused an issue for any new deployments that utilize the package.

This change is a suggestion to set the `@grpc/grpc-js` version to a static `1.8.1` for the time being. A patch for this issue has already been deployed in [v1.8.3](https://github.com/grpc/grpc-node/releases/tag/%40grpc%2Fgrpc-js%401.8.3) of the library, but we decided against utilizing this version until it has had time to be further tested and verified as working.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph-js/164)
<!-- Reviewable:end -->
