### PR TITLE
remove eslint

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -27,7 +27,6 @@ lint:
         - generated/**
   enabled:
     - trivy@0.59.1
-    - eslint@9.19.0
     - actionlint@1.7.7
     - checkov@3.2.365
     - git-diff-check

--- a/examples/simple/index.js
+++ b/examples/simple/index.js
@@ -1,5 +1,4 @@
-import * as dgraph from "dgraph-js"
-
+const dgraph = require("dgraph-js")
 // Drop All - discard all data, schema and start from a clean slate.
 async function dropAll(dgraphClient) {
   const op = new dgraph.Operation()

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -1,6 +1,5 @@
 {
   "name": "simple",
-  "type": "module",
   "dependencies": {
     "dgraph-js": "^24.1.0",
     "@grpc/grpc-js": "1.8.22"

--- a/examples/tls/index.js
+++ b/examples/tls/index.js
@@ -1,7 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-
-import * as dgraph from "dgraph-js";
+const dgraph = require("dgraph-js")
 
 // Create a client stub.
 function newClientStub() {

--- a/examples/tls/package.json
+++ b/examples/tls/package.json
@@ -1,6 +1,5 @@
 {
   "name": "tls",
-  "type": "module",
   "dependencies": {
     "dgraph-js": "^24.0.0"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,7 +3,6 @@
   "version": "24.1.0",
   "lockfileVersion": 3,
   "requires": true,
-  "type":"module",
   "packages": {
     "": {
       "name": "dgraph-js",

--- a/package.json
+++ b/package.json
@@ -32,8 +32,6 @@
     "@trunkio/launcher": "^1.3.2",
     "@types/google-protobuf": "^3.15.12",
     "@types/node": "^22.10.5",
-    "eslint": "^9.18.0",
-    "@eslint/js": "^9.18.0",
     "grpc-tools": "^1.12.4",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "24.1.0",
   "description": "Official javascript client for Dgraph",
   "license": "Apache-2.0",
-  "type": "module",
   "repository": {
     "type": "git",
     "url": "https://github.com/hypermodeinc/dgraph-js.git"


### PR DESCRIPTION
This change ensures compatibility with projects using CommonJS (require())
by removing the "type": "module" field from dgraph-js's package.json.