### PR TITLE
Remove runtime log

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -107,7 +107,7 @@ export class DgraphClient {
     this.clients.forEach((clientStub) => {
       try {
         clientStub.close() // Call the close method on each client stub
-        console.log('Closed client stub successfully')
+        this.debug('Closed client stub successfully.')
       } catch (error) {
         console.error('Failed to close client stub:', error)
       }


### PR DESCRIPTION
This small console.log was showing up when testing with the driver. 

This PR switches it to use `this.debug`. 

<img width="893" alt="Screenshot 2025-06-03 at 19 22 36" src="https://github.com/user-attachments/assets/fa81738b-72c3-43bb-91f1-d268e1884336" />
